### PR TITLE
New command - Timestamps

### DIFF
--- a/src/mritk/looklocker.py
+++ b/src/mritk/looklocker.py
@@ -314,7 +314,9 @@ def add_arguments(
     dicom_parser.add_argument("-i", "--input", type=Path, help="Path to the input Look-Locker DICOM file")
     dicom_parser.add_argument("-o", "--output", type=Path, help="Desired output path for the converted .nii.gz file")
 
-    ll_timestamps = subparser.add_parser("timestamps", help="Read timestamps from DICOM data", formatter_class=parser.formatter_class)
+    ll_timestamps = subparser.add_parser(
+        "timestamps", help="Read timestamps from DICOM data", formatter_class=parser.formatter_class
+    )
     ll_timestamps.add_argument("-i", "--input", type=Path, help="Path to the input Look-Locker DICOM file")
     ll_timestamps.add_argument("-o", "--output", type=Path, help="Desired output path for the generated file")
 

--- a/src/mritk/looklocker.py
+++ b/src/mritk/looklocker.py
@@ -23,7 +23,7 @@ from .utils import fit_voxel, mri_facemask, nan_filter_gaussian, run_dcm2niix
 logger = logging.getLogger(__name__)
 
 
-def read_dicom_trigger_times(dicomfile: Path) -> np.ndarray:
+def read_dicom_trigger_times(dicomfile: Path, output: Path | None = None) -> np.ndarray:
     """
     Extracts unique nominal cardiac trigger delay times from DICOM functional groups.
 
@@ -41,6 +41,10 @@ def read_dicom_trigger_times(dicomfile: Path) -> np.ndarray:
     all_frame_times = [
         f.CardiacSynchronizationSequence[0].NominalCardiacTriggerDelayTime for f in dcm.PerFrameFunctionalGroupsSequence
     ]
+
+    if output is not None:
+        np.savetxt(output, all_frame_times)
+
     return np.unique(all_frame_times)
 
 
@@ -310,6 +314,10 @@ def add_arguments(
     dicom_parser.add_argument("-i", "--input", type=Path, help="Path to the input Look-Locker DICOM file")
     dicom_parser.add_argument("-o", "--output", type=Path, help="Desired output path for the converted .nii.gz file")
 
+    ll_timestamps = subparser.add_parser("timestamps", help="Read timestamps from DICOM data", formatter_class=parser.formatter_class)
+    ll_timestamps.add_argument("-i", "--input", type=Path, help="Path to the input Look-Locker DICOM file")
+    ll_timestamps.add_argument("-o", "--output", type=Path, help="Desired output path for the generated file")
+
     ll_t1 = subparser.add_parser("t1", help="Generate a T1 map from Look-Locker data", formatter_class=parser.formatter_class)
     ll_t1.add_argument("-i", "--input", type=Path, help="Path to the 4D Look-Locker NIfTI file")
     ll_t1.add_argument("-t", "--timestamps", type=Path, help="Path to the text file containing trigger delay times (in ms)")
@@ -336,12 +344,15 @@ def add_arguments(
         extra_args_cb(dicom_parser)
         extra_args_cb(ll_t1)
         extra_args_cb(ll_post)
+        extra_args_cb(ll_timestamps)
 
 
 def dispatch(args):
     command = args.pop("looklocker-command")
     if command == "dcm2ll":
         dicom_to_looklocker(args.pop("input"), args.pop("output"))
+    elif command == "timestamps":
+        read_dicom_trigger_times(args.pop("input"), args.pop("output"))
     elif command == "t1":
         looklocker_t1map(args.pop("input"), args.pop("timestamps"), output=args.pop("output"))
     elif command == "postprocess":

--- a/src/mritk/looklocker.py
+++ b/src/mritk/looklocker.py
@@ -23,7 +23,7 @@ from .utils import fit_voxel, mri_facemask, nan_filter_gaussian, run_dcm2niix
 logger = logging.getLogger(__name__)
 
 
-def read_dicom_trigger_times(dicomfile: Path, output: Path | None = None) -> np.ndarray:
+def read_dicom_trigger_times(dicomfile: Path) -> np.ndarray:
     """
     Extracts unique nominal cardiac trigger delay times from DICOM functional groups.
 
@@ -41,9 +41,6 @@ def read_dicom_trigger_times(dicomfile: Path, output: Path | None = None) -> np.
     all_frame_times = [
         f.CardiacSynchronizationSequence[0].NominalCardiacTriggerDelayTime for f in dcm.PerFrameFunctionalGroupsSequence
     ]
-
-    if output is not None:
-        np.savetxt(output, all_frame_times)
 
     return np.unique(all_frame_times)
 
@@ -352,7 +349,9 @@ def dispatch(args):
     if command == "dcm2ll":
         dicom_to_looklocker(args.pop("input"), args.pop("output"))
     elif command == "timestamps":
-        read_dicom_trigger_times(args.pop("input"), args.pop("output"))
+        timestamps = read_dicom_trigger_times(args.pop("input"))
+        if args.pop("output") is not None:
+            np.savetxt(args.pop("output"), timestamps)
     elif command == "t1":
         looklocker_t1map(args.pop("input"), args.pop("timestamps"), output=args.pop("output"))
     elif command == "postprocess":


### PR DESCRIPTION
Adding new command `timestamps` in `mritk looklocker` to generate the timestamps file used as input when computing looklocker T1 map (`--timestamps` argument when calling `mritk looklocker t1`)