### PR TITLE
Make pydicom and dcm2niix optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,6 @@ dependencies = [
   "pandas",
   "scipy",
   "scikit-image",
-  "pydicom",
-  "dcm2niix",
 ]
 
 [project.optional-dependencies]
@@ -40,7 +38,12 @@ napari = [
 test = [
     "pytest",
     "pytest-cov",
+    "mritk[dicom]",
 
+]
+dicom = [
+    "pydicom", # Used for handling DICOM files
+    "dcm2niix", # Used for converting DICOM to NIfTI
 ]
 pypi = [
     "build" # Used for building wheels and uploading to pypi


### PR DESCRIPTION
Primarily due to failing build on conda, but in most cases people will not need these packages anyway. 